### PR TITLE
fix: fixed json error

### DIFF
--- a/src/components/QuasarTiptap.vue
+++ b/src/components/QuasarTiptap.vue
@@ -262,7 +262,7 @@ export default {
       }
 
       // From JSON
-      if (this.json.type) {
+      if (this.json && this.json.type) {
         this.editor.setContent(this.json, true)
       }
       if (this.html) {


### PR DESCRIPTION
Hello,

Added in another check to see if `this.json` is actually set before trying to check for the property `type` on `this.json` as I was encountering this error in the console when trying to pre-load tip-tap with content
![image](https://user-images.githubusercontent.com/35469763/84398642-1cb3b580-abf8-11ea-93a7-a3c50a768210.png)
