### PR TITLE
fix(editor): Restrict selected cell count in this editor instance

### DIFF
--- a/src/components/QuasarTiptap.vue
+++ b/src/components/QuasarTiptap.vue
@@ -210,7 +210,7 @@ export default {
           this.$emit('update', { getJSON, getHTML, state, transaction })
         },
         onTransaction: ({ getJSON, getHTML, state, transaction }) => {
-          const selectedCellElements = document.querySelectorAll('.selectedCell')
+          const selectedCellElements = this.editor.view.dom.querySelectorAll('.selectedCell')
           this.selectedCellSize = selectedCellElements.length
 
           this.$emit('transaction', { getJSON, getHTML, state, transaction })


### PR DESCRIPTION
The menububble should not be hidden when any other editor instance has selected cells, in case there are more editors in the same page.